### PR TITLE
Am 482 api download implement fetch document binary content junit

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -4,14 +4,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.ccd.document.am.model.StoredDocumentHalResource;
 import uk.gov.hmcts.reform.ccd.document.am.service.DocumentManagementService;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,8 +25,6 @@ public class CaseDocumentAmControllerTest {
 
     private transient ResponseEntity responseEntity = new ResponseEntity(HttpStatus.OK);
     private transient String serviceAuthorization = "";
-
-    HttpServletRequest mockedRequest = Mockito.mock(HttpServletRequest.class);
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
JIRA link (if applicable)
Story : https://tools.hmcts.net/jira/browse/AM-457
Task : https://tools.hmcts.net/jira/browse/AM-482

Change description
Case Document AM API-Download: Initial set of unit tests for AM-482 download binary content.

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[ x] No