### PR TITLE
AM-481 - Hotfix for getHashCode api

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAm.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAm.java
@@ -244,13 +244,6 @@ public interface CaseDocumentAm {
         @ApiParam("Authorization header of the currently authenticated user")
         @RequestHeader(value = "Authorization", required = true) String authorization,
 
-        @ApiParam(value = "documentId", required = true) @PathVariable("documentId") UUID documentId,
-
-        @ApiParam(value = "CaseType identifier for the case document.", required = true)
-        @RequestHeader(value = "caseTypeId", required = true) String caseTypeId,
-
-        @ApiParam(value = "Jurisdiction identifier for the case document.", required = true)
-        @RequestHeader(value = "jurisdictionId", required = true) String jurisdictionId);
-
+        @ApiParam(value = "documentId", required = true) @PathVariable("documentId") UUID documentId);
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -28,7 +28,9 @@ import uk.gov.hmcts.reform.ccd.document.am.service.common.ValidationService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
 public class CaseDocumentAmControllerTest {
@@ -402,30 +405,26 @@ public class CaseDocumentAmControllerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void generateHashCode_HappyPath() {
-        ResponseEntity<Object> responseEntity = testee.generateHashCode("", "", UUID.fromString(MATCHED_DOCUMENT_ID), BEFTA_CASETYPE_2, BEFTA_JURISDICTION_2);
+        Map<String, String> myMap = new HashMap<>();
+        myMap.put("caseId",CASE_ID);
+        myMap.put("caseTypeId", BEFTA_CASETYPE_2);
+        myMap.put("jurisdictionId", BEFTA_JURISDICTION_2);
+        StoredDocumentHalResource storedDocumentHalResource = new StoredDocumentHalResource();
+        storedDocumentHalResource.setMetadata(myMap);
+
+        when(documentManagementService.getDocumentMetadata(UUID.fromString(MATCHED_DOCUMENT_ID)))
+            .thenReturn(new ResponseEntity(storedDocumentHalResource, HttpStatus.OK));
+
+        ResponseEntity<Object> responseEntity = testee.generateHashCode("", "", UUID.fromString(MATCHED_DOCUMENT_ID));
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     }
 
     @Test //this test returns an illegal argument exception because UUID.fromString() contains a throw for illegal arguments
     void generateHashCode_BadRequest() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            testee.generateHashCode("", "", UUID.fromString("A.A"), BEFTA_CASETYPE_2, BEFTA_JURISDICTION_2);
-        });
-    }
-
-    //this test and the next return Bad Request because the exception handler seems to be made in a way that it trys to return the actual exception thrown
-    @Test
-    void generateHashCode_BadRequest2() {
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            testee.generateHashCode("", "", UUID.fromString(MATCHED_DOCUMENT_ID), "A.A", BEFTA_JURISDICTION_2);
-        });
-    }
-
-    @Test
-    void generateHashCode_BadRequest3() {
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            testee.generateHashCode("","", UUID.fromString(MATCHED_DOCUMENT_ID), BEFTA_CASETYPE_2, "A.A");
+            testee.generateHashCode("", "", UUID.fromString("A.A"));
         });
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/AM-481

### Change description ###

We no longer are passing caseTypeId and jurisdictionId into the getHashCode api. We  now are using the getDocumentMetadata endpoint to retrieve them.