### PR TITLE
Am 629 add salt to hashing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmController.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmController.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -54,6 +55,9 @@ public class CaseDocumentAmController  {
     private static final Logger LOG = LoggerFactory.getLogger(CaseDocumentAmController.class);
 
     private DocumentManagementService  documentManagementService;
+
+    @Value("${idam.s2s-auth.totp_secret}")
+    protected String salt;
 
     @Autowired
     public CaseDocumentAmController(DocumentManagementService documentManagementService) {
@@ -229,6 +233,7 @@ public class CaseDocumentAmController  {
     @GetMapping(value = "/cases/documents/{documentId}/token", produces = {APPLICATION_JSON})
     public ResponseEntity<Object> generateHashCode(
         @PathVariable("documentId") UUID documentId) {
+
         StoredDocumentHalResource resource = new StoredDocumentHalResource();
         ResponseEntity responseEntity = documentManagementService.getDocumentMetadata(documentId);
         if (responseEntity.getStatusCode().equals(HttpStatus.OK) && null != responseEntity.getBody()) {
@@ -242,6 +247,7 @@ public class CaseDocumentAmController  {
 
         String hashedToken = ApplicationUtils.generateHashCode(documentId.toString().concat(
             resource.getMetadata().get("jurisdictionId")).concat(resource.getMetadata().get("caseTypeId")));
+        hashedToken += salt;
         responseBody.put(HASHCODE, hashedToken);
 
         return new ResponseEntity<>(responseBody, HttpStatus.OK);

--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmController.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmController.java
@@ -245,9 +245,8 @@ public class CaseDocumentAmController  {
 
         HashMap<String, String> responseBody = new HashMap<>();
 
-        String hashedToken = ApplicationUtils.generateHashCode(documentId.toString().concat(
-            resource.getMetadata().get("jurisdictionId")).concat(resource.getMetadata().get("caseTypeId")));
-        hashedToken += salt;
+        String hashedToken = ApplicationUtils.generateHashCode(salt.concat(documentId.toString().concat(
+            resource.getMetadata().get("jurisdictionId")).concat(resource.getMetadata().get("caseTypeId"))));
         responseBody.put(HASHCODE, hashedToken);
 
         return new ResponseEntity<>(responseBody, HttpStatus.OK);

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -409,9 +409,7 @@ public class CaseDocumentAmControllerTest {
         ResponseEntity<Object> responseEntity = testee.generateHashCode(UUID.fromString(MATCHED_DOCUMENT_ID));
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 
-        String salt = "CNTOE7D2NX6XHBKT";
-        assertEquals(String.format("{hashcode=6db468629a7bc771c1b2a0675568ae367acb79804ca24e3cca509279b0ebe3e9%s}",
-                                   salt), responseEntity.getBody().toString());
+        assertEquals("{hashcode=a68e9940e9d5a0fc1ef6ad976dc3449861ba00b55a5123c0534d6c0557a0f728}", responseEntity.getBody().toString());
     }
 
     @Test //this test returns an illegal argument exception because UUID.fromString() contains a throw for illegal arguments

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.ccd.document.am.controller.advice.exception.BadRequestException;
 import uk.gov.hmcts.reform.ccd.document.am.controller.advice.exception.ForbiddenException;
@@ -392,6 +394,9 @@ public class CaseDocumentAmControllerTest {
     @Test
     @SuppressWarnings("unchecked")
     void generateHashCode_HappyPath() {
+
+        ReflectionTestUtils.setField(testee, "salt", "CNTOE7D2NX6XHBKT");
+
         Map<String, String> myMap = new HashMap<>();
         myMap.put("caseId",CASE_ID);
         myMap.put("caseTypeId", BEFTA_CASETYPE_2);
@@ -404,6 +409,10 @@ public class CaseDocumentAmControllerTest {
 
         ResponseEntity<Object> responseEntity = testee.generateHashCode(UUID.fromString(MATCHED_DOCUMENT_ID));
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+        String salt = "CNTOE7D2NX6XHBKT";
+        assertEquals(String.format("{hashcode=6db468629a7bc771c1b2a0675568ae367acb79804ca24e3cca509279b0ebe3e9%s}",
+                                   salt), responseEntity.getBody().toString());
     }
 
     @Test //this test returns an illegal argument exception because UUID.fromString() contains a throw for illegal arguments

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -394,7 +394,7 @@ public class CaseDocumentAmControllerTest {
     @SuppressWarnings("unchecked")
     void generateHashCode_HappyPath() {
 
-        ReflectionTestUtils.setField(testee, "salt", "CNTOE7D2NX6XHBKT");
+        ReflectionTestUtils.setField(testee, "salt", "AAAOA7A2AA6AAAA5");
 
         Map<String, String> myMap = new HashMap<>();
         myMap.put("caseId",CASE_ID);
@@ -409,7 +409,7 @@ public class CaseDocumentAmControllerTest {
         ResponseEntity<Object> responseEntity = testee.generateHashCode(UUID.fromString(MATCHED_DOCUMENT_ID));
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 
-        assertEquals("{hashcode=a68e9940e9d5a0fc1ef6ad976dc3449861ba00b55a5123c0534d6c0557a0f728}", responseEntity.getBody().toString());
+        assertEquals("{hashcode=a54bbca80a425a73ddaa27f12076fb09981da48c30bbbe74b68bf46cb7762dcb}", responseEntity.getBody().toString());
     }
 
     @Test //this test returns an illegal argument exception because UUID.fromString() contains a throw for illegal arguments

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/controller/endpoints/CaseDocumentAmControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/AM-629

### Change description ###

We are appending s2s secret to end of hash in a salt like way.
This is because we require the hash to be predictable for patching documents.
