### PR TITLE
Clean up code

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/CaseDataStoreServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/CaseDataStoreServiceImpl.java
@@ -54,6 +54,7 @@ public class CaseDataStoreServiceImpl implements CaseDataStoreService {
     @Override
     @SuppressWarnings("unchecked")
     public Optional<DocumentPermissions> getCaseDocumentMetadata(String caseId, UUID documentId) {
+        Optional<DocumentPermissions> result = Optional.empty();
         try {
             HttpHeaders headers = prepareRequestForUpload();
             HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(headers);
@@ -69,7 +70,7 @@ public class CaseDataStoreServiceImpl implements CaseDataStoreService {
                                                                                        CaseDocumentMetadata.class);
 
                 if (documentMetadata != null && documentMetadata.getDocumentPermissions() != null) {
-                    return Optional.of(documentMetadata.getDocumentPermissions());
+                    result = Optional.of(documentMetadata.getDocumentPermissions());
                 } else {
                     LOG.error(ERROR_MESSAGE, caseId, HttpStatus.FORBIDDEN);
                     throw new ForbiddenException(CASE_ERROR_MESSAGE + caseId);
@@ -94,7 +95,7 @@ public class CaseDataStoreServiceImpl implements CaseDataStoreService {
                 ));
             }
         }
-        return Optional.empty();
+        return result;
     }
 
     private HttpHeaders prepareRequestForUpload() {

--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
@@ -136,7 +136,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
 
     @Override
     public ResponseEntity<Object> getDocumentMetadata(UUID documentId) {
-
+        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<String> requestEntity = new HttpEntity<>(getHttpHeaders());
             LOG.info("Document Store URL is : {}", documentURL);
@@ -153,7 +153,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             ResponseEntity<Object> responseEntity = ResponseHelper.toResponseEntity(response, documentId);
             if (HttpStatus.OK.equals(responseEntity.getStatusCode())) {
                 LOG.info("Positive response");
-                return responseEntity;
+                responseReturn = responseEntity;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store {}", responseEntity
                     .getStatusCode());
@@ -162,7 +162,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseReturn;
 
     }
 
@@ -177,6 +177,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
 
     @Override
     public ResponseEntity<Object> getDocumentBinaryContent(UUID documentId) {
+        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<?> requestEntity = new HttpEntity<>(getHttpHeaders());
             String documentBinaryUrl = String.format("%s/documents/%s/binary", documentURL, documentId);
@@ -187,10 +188,10 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
                 ByteArrayResource.class
                                                                               );
             if (HttpStatus.OK.equals(response.getStatusCode())) {
-                return ResponseEntity.ok().headers(getHeaders(response))
+                responseReturn =  ResponseEntity.ok().headers(getHeaders(response))
                                      .body(response.getBody());
             } else {
-                return ResponseEntity
+                responseReturn = ResponseEntity
                     .status(response.getStatusCode())
                     .body(response.getBody());
             }
@@ -198,7 +199,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseReturn;
 
     }
 
@@ -278,6 +279,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     @Override
     public ResponseEntity<Object> uploadDocuments(List<MultipartFile> files, String classification,
                                                    String caseTypeId, String jurisdictionId) {
+        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
         try {
             LinkedMultiValueMap<String, Object> bodyMap = new LinkedMultiValueMap<>();
             HttpHeaders headers = prepareRequestForUpload(classification, caseTypeId, jurisdictionId, bodyMap);
@@ -299,17 +301,18 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
                 formatUploadDocumentResponse(caseTypeId, jurisdictionId, uploadedDocumentResponse);
             }
 
-            return ResponseEntity
+            responseReturn = ResponseEntity
                 .status(uploadedDocumentResponse.getStatusCode())
                 .body(uploadedDocumentResponse.getBody());
         } catch (HttpClientErrorException exception) {
             catchException(exception, EXCEPTION_ERROR_MESSAGE);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseReturn;
     }
 
     @Override
     public ResponseEntity<Object> patchDocument(UUID documentId, UpdateDocumentCommand ttl) {
+        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
         if (!ValidationService.validateTTL(ttl.getTtl())) {
             throw new BadRequestException(String.format(
                 "Incorrect date format %s",
@@ -326,7 +329,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             );
             ResponseEntity<Object> responseEntity = ResponseHelper.toResponseEntity(response, documentId);
             if (HttpStatus.OK.equals(responseEntity.getStatusCode())) {
-                return responseEntity;
+                responseReturn = responseEntity;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store API Side {}", response
                     .getStatusCode());
@@ -335,12 +338,12 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseReturn;
     }
 
     @Override
     public ResponseEntity<Object> deleteDocument(UUID documentId,  Boolean permanent) {
-
+        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<?> requestEntity = new HttpEntity<>(getHttpHeaders());
             String documentDeleteUrl = String.format("%s/documents/%s?permanent=%s", documentURL, documentId, permanent);
@@ -353,7 +356,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             );
             if (HttpStatus.NO_CONTENT.equals(response.getStatusCode())) {
                 LOG.info("Positive response");
-                return response;
+                responseReturn = response;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store {}", response
                     .getStatusCode());
@@ -362,7 +365,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseReturn;
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
@@ -135,7 +135,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
 
     @Override
     public ResponseEntity<Object> getDocumentMetadata(UUID documentId) {
-        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
+        ResponseEntity<Object> responseResult = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<String> requestEntity = new HttpEntity<>(getHttpHeaders());
             LOG.info("Document Store URL is : {}", documentURL);
@@ -152,7 +152,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             ResponseEntity<Object> responseEntity = ResponseHelper.toResponseEntity(response, documentId);
             if (HttpStatus.OK.equals(responseEntity.getStatusCode())) {
                 LOG.info("Positive response");
-                responseReturn = responseEntity;
+                responseResult = responseEntity;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store {}", responseEntity
                     .getStatusCode());
@@ -161,7 +161,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return responseReturn;
+        return responseResult;
 
     }
 
@@ -176,7 +176,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
 
     @Override
     public ResponseEntity<Object> getDocumentBinaryContent(UUID documentId) {
-        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
+        ResponseEntity<Object> responseResult = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<?> requestEntity = new HttpEntity<>(getHttpHeaders());
             String documentBinaryUrl = String.format("%s/documents/%s/binary", documentURL, documentId);
@@ -187,10 +187,10 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
                 ByteArrayResource.class
                                                                               );
             if (HttpStatus.OK.equals(response.getStatusCode())) {
-                responseReturn =  ResponseEntity.ok().headers(getHeaders(response))
+                responseResult =  ResponseEntity.ok().headers(getHeaders(response))
                                      .body(response.getBody());
             } else {
-                responseReturn = ResponseEntity
+                responseResult = ResponseEntity
                     .status(response.getStatusCode())
                     .body(response.getBody());
             }
@@ -198,7 +198,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return responseReturn;
+        return responseResult;
 
     }
 
@@ -278,7 +278,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     @Override
     public ResponseEntity<Object> uploadDocuments(List<MultipartFile> files, String classification,
                                                    String caseTypeId, String jurisdictionId) {
-        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
+        ResponseEntity<Object> responseResult = new ResponseEntity<>(HttpStatus.OK);
         try {
             LinkedMultiValueMap<String, Object> bodyMap = new LinkedMultiValueMap<>();
             HttpHeaders headers = prepareRequestForUpload(classification, caseTypeId, jurisdictionId, bodyMap);
@@ -300,18 +300,18 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
                 formatUploadDocumentResponse(caseTypeId, jurisdictionId, uploadedDocumentResponse);
             }
 
-            responseReturn = ResponseEntity
+            responseResult = ResponseEntity
                 .status(uploadedDocumentResponse.getStatusCode())
                 .body(uploadedDocumentResponse.getBody());
         } catch (HttpClientErrorException exception) {
             catchException(exception, EXCEPTION_ERROR_MESSAGE);
         }
-        return responseReturn;
+        return responseResult;
     }
 
     @Override
     public ResponseEntity<Object> patchDocument(UUID documentId, UpdateDocumentCommand ttl) {
-        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
+        ResponseEntity<Object> responseResult = new ResponseEntity<>(HttpStatus.OK);
         if (!ValidationService.validateTTL(ttl.getTtl())) {
             throw new BadRequestException(String.format(
                 "Incorrect date format %s",
@@ -328,7 +328,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             );
             ResponseEntity<Object> responseEntity = ResponseHelper.toResponseEntity(response, documentId);
             if (HttpStatus.OK.equals(responseEntity.getStatusCode())) {
-                responseReturn = responseEntity;
+                responseResult = responseEntity;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store API Side {}", response
                     .getStatusCode());
@@ -337,12 +337,12 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return responseReturn;
+        return responseResult;
     }
 
     @Override
     public ResponseEntity<Object> deleteDocument(UUID documentId,  Boolean permanent) {
-        ResponseEntity<Object> responseReturn = new ResponseEntity<>(HttpStatus.OK);
+        ResponseEntity<Object> responseResult = new ResponseEntity<>(HttpStatus.OK);
         try {
             final HttpEntity<?> requestEntity = new HttpEntity<>(getHttpHeaders());
             String documentDeleteUrl = String.format("%s/documents/%s?permanent=%s", documentURL, documentId, permanent);
@@ -355,7 +355,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             );
             if (HttpStatus.NO_CONTENT.equals(response.getStatusCode())) {
                 LOG.info("Positive response");
-                responseReturn = response;
+                responseResult = response;
             } else {
                 LOG.error("Document doesn't exist for requested document id at Document Store {}", response
                     .getStatusCode());
@@ -364,7 +364,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         } catch (HttpClientErrorException exception) {
             catchException(exception, documentId.toString(), EXCEPTION_ERROR_ON_DOCUMENT_MESSAGE);
         }
-        return responseReturn;
+        return responseResult;
     }
 
 

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
@@ -579,7 +579,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_HappyPath() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -607,7 +606,6 @@ class DocumentManagementServiceImplTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_NotFoundException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -641,7 +639,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_ForbiddenException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -675,7 +672,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_BadRequestException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -709,7 +705,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_ForbiddenException_InvalidHashToken() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -744,7 +739,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_BadGatewayException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -1228,7 +1222,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void checkUserPermissionTest2() {
         StoredDocumentHalResource storedDocumentHalResource = new StoredDocumentHalResource();
         Map<String, String> myMap = new HashMap<>();
@@ -1250,7 +1243,6 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void checkUserPermissionTest3() {
         StoredDocumentHalResource storedDocumentHalResource = new StoredDocumentHalResource();
         Map<String, String> myMap = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
@@ -579,6 +579,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_HappyPath() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -606,6 +607,7 @@ class DocumentManagementServiceImplTest {
 
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_NotFoundException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -639,6 +641,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_ForbiddenException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -672,6 +675,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_BadRequestException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -705,6 +709,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_ForbiddenException_InvalidHashToken() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -739,6 +744,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void patchDocumentMetadata_Throws_BadGatewayException() {
         DocumentHashToken doc = DocumentHashToken.builder().id(MATCHED_DOCUMENT_ID)
             .hashToken(ApplicationUtils.generateHashCode(salt.concat(MATCHED_DOCUMENT_ID).concat(BEFTA_JURISDICTION_2).concat(BEFTA_CASETYPE_2))).build();
@@ -1222,6 +1228,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void checkUserPermissionTest2() {
         StoredDocumentHalResource storedDocumentHalResource = new StoredDocumentHalResource();
         Map<String, String> myMap = new HashMap<>();
@@ -1243,6 +1250,7 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void checkUserPermissionTest3() {
         StoredDocumentHalResource storedDocumentHalResource = new StoredDocumentHalResource();
         Map<String, String> myMap = new HashMap<>();


### PR DESCRIPTION
Multiple returns in one method is generally considered not best practice.

It is not so much an issue these days with modern languages but helps in readability of the code.

It also complies with the idea of structured programming.

The outside returns were never hit in any test case I could think of.
So they would count as uncovered lines in our coverage reports.
This is because an exception would be thrown if the first return isn't hit in any case.