### PR TITLE
Service Auth minor issue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/apihelper/Constants.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/apihelper/Constants.java
@@ -65,6 +65,7 @@ public class Constants {
     public static final String TTL = "ttl";
     public static final String CREATED_ON = "createdOn";
     public static final String DOCUMENT_LINKS = "links";
+    public static final String EXCEPTION_SERVICE_ID_NOT_AUTHORISED = "Service Id is not authorized to access API: %s ";
 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
@@ -532,7 +532,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             return service.get();
         } else {
             LOG.error("Service Id {} is not authorized to access API ", serviceId);
-            throw new BadRequestException(String.format(EXCEPTION_SERVICE_ID_NOT_AUTHORISED, serviceId));
+            throw new ForbiddenException(String.format(EXCEPTION_SERVICE_ID_NOT_AUTHORISED, serviceId));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImpl.java
@@ -91,6 +91,7 @@ import static uk.gov.hmcts.reform.ccd.document.am.apihelper.Constants.USERID;
 import static uk.gov.hmcts.reform.ccd.document.am.apihelper.Constants.CREATED_BY;
 import static uk.gov.hmcts.reform.ccd.document.am.apihelper.Constants.LAST_MODIFIED_BY;
 import static uk.gov.hmcts.reform.ccd.document.am.apihelper.Constants.MODIFIED_ON;
+import static uk.gov.hmcts.reform.ccd.document.am.apihelper.Constants.EXCEPTION_SERVICE_ID_NOT_AUTHORISED;
 
 @Slf4j
 @Service
@@ -527,7 +528,12 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     private AuthorisedService getServiceDetailsFromJson(String serviceId) {
         Optional<AuthorisedService> service = authorisedServices.getAuthServices().stream().filter(s -> s.getId().equals(
             serviceId)).findAny();
-        return service.orElse(null);
+        if (service.isPresent()) {
+            return service.get();
+        } else {
+            LOG.error("Service Id {} is not authorized to access API ", serviceId);
+            throw new BadRequestException(String.format(EXCEPTION_SERVICE_ID_NOT_AUTHORISED, serviceId));
+        }
     }
 
     private String extractCaseTypeIdFromMetadata(Object storedDocument) {

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
@@ -457,6 +457,15 @@ class DocumentManagementServiceImplTest {
     }
 
     @Test
+    void checkServicePermission_WhenServiceIdIsNotAuthorised() {
+        when(securityUtilsMock.getServiceId()).thenReturn("ccd_case_document_am_api");
+        mockitoWhenRestExchangeThenThrow(initialiseMetaDataMap("1234567812345678", "caseTypeId", "BEFTA_JURISDICTION_2"), HttpStatus.OK);
+        assertThrows(BadRequestException.class, () -> {
+            sut.checkServicePermission(new ResponseEntity<>(HttpStatus.OK), Permission.READ);
+        });
+    }
+
+    @Test
     void checkUserPermission_Throws_CaseNotFoundException() {
         mockitoWhenRestExchangeThenThrow(initialiseMetaDataMap("1234567890123456", "", ""), HttpStatus.OK);
         ResponseEntity responseEntity = sut.getDocumentMetadata(matchedDocUUID);

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
@@ -458,7 +458,7 @@ class DocumentManagementServiceImplTest {
 
     @Test
     void checkServicePermission_WhenServiceIdIsNotAuthorised() {
-        when(securityUtilsMock.getServiceId()).thenReturn("ccd_case_document_am_api");
+        when(securityUtilsMock.getServiceId()).thenReturn("bad_Service_name");
         mockitoWhenRestExchangeThenThrow(initialiseMetaDataMap("1234567812345678", "caseTypeId", "BEFTA_JURISDICTION_2"), HttpStatus.OK);
         assertThrows(BadRequestException.class, () -> {
             sut.checkServicePermission(new ResponseEntity<>(HttpStatus.OK), Permission.READ);

--- a/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/document/am/service/impl/DocumentManagementServiceImplTest.java
@@ -460,7 +460,7 @@ class DocumentManagementServiceImplTest {
     void checkServicePermission_WhenServiceIdIsNotAuthorised() {
         when(securityUtilsMock.getServiceId()).thenReturn("bad_Service_name");
         mockitoWhenRestExchangeThenThrow(initialiseMetaDataMap("1234567812345678", "caseTypeId", "BEFTA_JURISDICTION_2"), HttpStatus.OK);
-        assertThrows(BadRequestException.class, () -> {
+        assertThrows(ForbiddenException.class, () -> {
             sut.checkServicePermission(new ResponseEntity<>(HttpStatus.OK), Permission.READ);
         });
     }


### PR DESCRIPTION
Service Auth minor fix :
If a service is is not authorised and not configured in service_config file, it should handle exception gracefully.