### PR TITLE
RDM-12766 - empty file content can now be passed to dm-store

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/ccd/documentam/controller/CaseDocumentAmControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/ccd/documentam/controller/CaseDocumentAmControllerIT.java
@@ -135,6 +135,47 @@ public class CaseDocumentAmControllerIT extends BaseTest implements TestFixture 
                 null));
     }
 
+    @Test
+    void shouldSuccessfullyUploadEmptyDocument() throws Exception {
+
+        Document document = Document.builder()
+            .originalDocumentName(ORIGINAL_DOCUMENT_NAME)
+            .size(0L)
+            .classification(Classification.PUBLIC)
+            .links(TestFixture.getLinks())
+            .build();
+
+        DmUploadResponse dmUploadResponse = DmUploadResponse.builder()
+            .embedded(DmUploadResponse.Embedded.builder().documents(List.of(document)).build())
+            .build();
+
+        stubDocumentManagementUploadDocument(dmUploadResponse);
+
+        final String expectedHash = ApplicationUtils.generateHashCode(
+            salt.concat(DOCUMENT_ID.toString().concat(JURISDICTION_ID_VALUE).concat(CASE_TYPE_ID_VALUE))
+        );
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(MAIN_URL)
+                            .part(new MockPart(FILES, "file", "".getBytes()))
+                            .part(new MockPart(CLASSIFICATION, CLASSIFICATION_VALUE.getBytes()))
+                            .part(new MockPart(CASE_TYPE_ID, CASE_TYPE_ID_VALUE.getBytes()))
+                            .part(new MockPart(JURISDICTION_ID, JURISDICTION_ID_VALUE.getBytes()))
+                            .headers(createHttpHeaders(SERVICE_NAME_XUI_WEBAPP))
+                            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.documents[0].originalDocumentName", is(ORIGINAL_DOCUMENT_NAME)))
+            .andExpect(jsonPath("$.documents[0].classification", is(Classification.PUBLIC.name())))
+            .andExpect(jsonPath("$.documents[0].size", is(0)))
+            .andExpect(jsonPath("$.documents[0].hashToken", is(expectedHash)))
+            .andExpect(jsonPath("$.documents[0]._links.self.href", is(SELF_LINK)))
+            .andExpect(jsonPath("$.documents[0]._links.binary.href", is(BINARY_LINK)))
+            .andExpect(hasGeneratedLogAudit(
+                AuditOperationType.UPLOAD_DOCUMENTS,
+                SERVICE_NAME_XUI_WEBAPP,
+                null,
+                null));
+    }
+
     @ParameterizedTest
     @MethodSource("provideDocumentUploadParameters")
     public void testShouldRaiseExceptionWhenUploadingDocumentsWithInvalidValues(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/ccd/documentam/controller/CaseDocumentAmControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/ccd/documentam/controller/CaseDocumentAmControllerIT.java
@@ -175,7 +175,9 @@ public class CaseDocumentAmControllerIT extends BaseTest implements TestFixture 
                 AuditOperationType.UPLOAD_DOCUMENTS,
                 SERVICE_NAME_XUI_WEBAPP,
                 null,
-                null));
+                null,
+                JURISDICTION_ID_VALUE,
+                CASE_TYPE_ID_VALUE));
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/hmcts/reform/ccd/documentam/client/dmstore/DocumentStoreClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/documentam/client/dmstore/DocumentStoreClient.java
@@ -145,9 +145,7 @@ public class DocumentStoreClient {
 
         documentUploadRequest.getFiles()
             .forEach(file -> {
-                if (!file.isEmpty()) {
-                    bodyMap.add(Constants.FILES, file.getResource());
-                }
+                bodyMap.add(Constants.FILES, file.getResource());
             });
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImplTest.java
@@ -605,53 +605,6 @@ class DocumentManagementServiceImplTest implements TestFixture {
     }
 
     @Test
-    void uploadDocuments_WithEmptyContent() {
-        final Document document = Document.builder()
-            .size(0L)
-            .mimeType(MIME_TYPE)
-            .originalDocumentName(ORIGINAL_DOCUMENT_NAME)
-            .classification(Classification.PUBLIC)
-            .links(TestFixture.getLinks())
-            .build();
-
-        final DmUploadResponse dmUploadResponse = DmUploadResponse.builder()
-            .embedded(DmUploadResponse.Embedded.builder().documents(List.of(document)).build())
-            .build();
-
-        stubGetSalt();
-        doReturn(dmUploadResponse).when(documentStoreClient).uploadDocuments(any(DocumentUploadRequest.class));
-
-        final String expectedHash = ApplicationUtils
-            .generateHashCode(SALT.concat(DOCUMENT_ID.toString()
-                                              .concat(JURISDICTION_ID_VALUE)
-                                              .concat(CASE_TYPE_ID_VALUE)));
-
-        final DocumentUploadRequest uploadRequest = new DocumentUploadRequest(
-            List.of(new MockMultipartFile("afile", "".getBytes())),
-            Classification.PUBLIC.name(),
-            CASE_TYPE_ID_VALUE,
-            JURISDICTION_ID_VALUE
-        );
-
-        final UploadResponse response = sut.uploadDocuments(uploadRequest);
-
-        assertThat(response.getDocuments())
-            .hasSize(1)
-            .first()
-            .satisfies(doc -> {
-                assertThat(doc.getClassification()).isEqualTo(Classification.PUBLIC);
-                assertThat(doc.getSize()).isEqualTo(0);
-                assertThat(doc.getMimeType()).isEqualTo(MIME_TYPE);
-                assertThat(doc.getOriginalDocumentName()).isEqualTo(ORIGINAL_DOCUMENT_NAME);
-                assertThat(doc.getHashToken()).isEqualTo(expectedHash);
-                assertThat(doc.getLinks().binary.href).isEqualTo(BINARY_LINK);
-                assertThat(doc.getLinks().self.href).isEqualTo(SELF_LINK);
-            });
-
-        verify(documentStoreClient).uploadDocuments(uploadRequest);
-    }
-
-    @Test
     @SuppressWarnings("ConstantConditions")
     void testUploadDocumentsWhenDmUploadResponseIsNull() {
         final DmUploadResponse dmUploadResponse = null;

--- a/src/test/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImplTest.java
@@ -605,6 +605,53 @@ class DocumentManagementServiceImplTest implements TestFixture {
     }
 
     @Test
+    void uploadDocuments_WithEmptyContent() {
+        final Document document = Document.builder()
+            .size(0L)
+            .mimeType(MIME_TYPE)
+            .originalDocumentName(ORIGINAL_DOCUMENT_NAME)
+            .classification(Classification.PUBLIC)
+            .links(TestFixture.getLinks())
+            .build();
+
+        final DmUploadResponse dmUploadResponse = DmUploadResponse.builder()
+            .embedded(DmUploadResponse.Embedded.builder().documents(List.of(document)).build())
+            .build();
+
+        stubGetSalt();
+        doReturn(dmUploadResponse).when(documentStoreClient).uploadDocuments(any(DocumentUploadRequest.class));
+
+        final String expectedHash = ApplicationUtils
+            .generateHashCode(SALT.concat(DOCUMENT_ID.toString()
+                                              .concat(JURISDICTION_ID_VALUE)
+                                              .concat(CASE_TYPE_ID_VALUE)));
+
+        final DocumentUploadRequest uploadRequest = new DocumentUploadRequest(
+            List.of(new MockMultipartFile("afile", "".getBytes())),
+            Classification.PUBLIC.name(),
+            CASE_TYPE_ID_VALUE,
+            JURISDICTION_ID_VALUE
+        );
+
+        final UploadResponse response = sut.uploadDocuments(uploadRequest);
+
+        assertThat(response.getDocuments())
+            .hasSize(1)
+            .first()
+            .satisfies(doc -> {
+                assertThat(doc.getClassification()).isEqualTo(Classification.PUBLIC);
+                assertThat(doc.getSize()).isEqualTo(0);
+                assertThat(doc.getMimeType()).isEqualTo(MIME_TYPE);
+                assertThat(doc.getOriginalDocumentName()).isEqualTo(ORIGINAL_DOCUMENT_NAME);
+                assertThat(doc.getHashToken()).isEqualTo(expectedHash);
+                assertThat(doc.getLinks().binary.href).isEqualTo(BINARY_LINK);
+                assertThat(doc.getLinks().self.href).isEqualTo(SELF_LINK);
+            });
+
+        verify(documentStoreClient).uploadDocuments(uploadRequest);
+    }
+
+    @Test
     @SuppressWarnings("ConstantConditions")
     void testUploadDocumentsWhenDmUploadResponseIsNull() {
         final DmUploadResponse dmUploadResponse = null;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-12766


### Change description ###
Bug fix for upload of empty content file


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
