### PR TITLE
CCD-2111: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.50',
+  tomcatEmbedded     : '9.0.54',
 ]
 
 pmd {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,4 +36,9 @@
     <cve>CVE-2021-33037</cve>
   </suppress>
 
+  <suppress until="2021-11-25">
+    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
+    <cve>CVE-2021-22096</cve>
+  </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,9 +36,4 @@
     <cve>CVE-2021-33037</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2111 (https://tools.hmcts.net/jira/browse/CCD-2111)


### Change description ###
- Updated build.gradle. Set value of tomcatEmbedded property to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
