### PR TITLE
CCD-2135: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ pmd {
   toolVersion = '6.21.0'
   sourceSets = []
 }
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 ext['spring-security.version'] = '5.4.7'
 
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,9 +36,4 @@
     <cve>CVE-2021-33037</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2135 (https://tools.hmcts.net/jira/browse/CCD-2135)


### Change description ###
- Updated build.gradle.  Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
