### PR TITLE
CCD-2177: Removed suppression of CVE-2021-33037

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -30,10 +30,4 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Inconsistent Interpretation of HTTP Requests
-    </notes>
-    <cve>CVE-2021-33037</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2177 (https://tools.hmcts.net/jira/browse/CCD-2177)


### Change description ###
- Removed temporary suppression of CVE-2021-33037 from suppressions.xml.  Issue was originally fixed in Pull Request 447 (https://github.com/hmcts/ccd-case-document-am-api/pull/447).  Suppression was added post-fix in Pull Request 432 (https://github.com/hmcts/ccd-case-document-am-api/pull/432) as a result of the merge of other development work being carried out at the same time.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
