### PR TITLE
Revert "Bump jackson-databind from 2.11.1 to 2.12.4"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ repositories {
 
 dependencies {
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
-  implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
+  implementation "com.fasterxml.jackson.core:jackson-databind:2.11.1"
 
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'


### PR DESCRIPTION
Reverts hmcts/ccd-case-document-am-api#439