### PR TITLE
CVE-2021-22060, CVE-2022-23181, CVE-2021-42550, CVE-2021-44832 fixes …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.54',
+  tomcatEmbedded     : '10.1.0-M10',
   serviceAuthVersion : '3.1.4',
 ]
 
@@ -290,8 +290,8 @@ dependencies {
   implementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
 
   // CVE-2022-23181
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.0-M10'
+  implementation "org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcatEmbedded}"
+  implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"
 
   //CVE-2021-42500

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '10.1.0-M10',
+  tomcatEmbedded     : '9.0.58',
   serviceAuthVersion : '3.1.4',
 ]
 
@@ -291,8 +291,8 @@ dependencies {
 
   // CVE-2022-23181
   implementation "org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcatEmbedded}"
-  implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"
+  implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
 
   //CVE-2021-42500
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'

--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ pmd {
   toolVersion = '6.21.0'
   sourceSets = []
 }
-ext['spring-framework.version'] = '5.3.12'
+ext['spring-framework.version'] = '5.3.15'
 ext['spring-security.version'] = '5.4.7'
-ext['log4j2.version'] = '2.17.0'
+ext['log4j2.version'] = '2.17.1'
 
 group = 'uk.gov.hmcts.reform.ccd.documentam'
 version = '0.0.1'
@@ -289,10 +289,14 @@ dependencies {
 
   implementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
 
-  // CVE-2021-25122
-  implementation "org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcatEmbedded}"
+  // CVE-2022-23181
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.0-M10'
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"
-  implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
+
+  //CVE-2021-42500
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
 
   // CVE-2021-28170
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,12 +29,5 @@
     <cve>CVE-2020-29244</cve>
     <cve>CVE-2020-29245</cve>
   </suppress>
-  
-  <suppress until="2022-02-25">
-    <cve>CVE-2021-22060</cve>
-    <cve>CVE-2022-23181</cve>
-    <cve>CVE-2021-42550</cve>
-    <cve>CVE-2021-44832</cve>
-  </suppress>
 
 </suppressions>


### PR DESCRIPTION
…and removing suppressions

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-2623
https://tools.hmcts.net/jira/browse/CCD-2636
https://tools.hmcts.net/jira/browse/CCD-2610
https://tools.hmcts.net/jira/browse/CCD-2584

### Change description ###

CVE-2021-22060, CVE-2022-23181, CVE-2021-42550, CVE-2021-44832

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
