### PR TITLE
CVE-2022-29885: ccd-case-document-am-api fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.58',
+  tomcatEmbedded     : '9.0.63',
   serviceAuthVersion : '3.1.4',
 ]
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,19 +35,4 @@
    ]]></notes>
     <cve>CVE-2016-1000027</cve>
   </suppress>
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3268

Upgrading tomcat version to 9.0.63.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
