### PR TITLE
CCD-3427 CVE-2022-34305 tomcat upgrade to 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.63',
+  tomcatEmbedded     : '9.0.65',
   serviceAuthVersion : '3.1.4',
 ]
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,7 +6,6 @@
     <notes>False Positives
       CVE-2016-1000027  refer https://tools.hmcts.net/jira/browse/CCD-3249
       CVE-2018-1258  refer https://tools.hmcts.net/jira/browse/CCD-460
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3427
       CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
       CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
       CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
@@ -15,7 +14,6 @@
     </notes>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2018-1258</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2022-22976</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3427
CVE-2022-34305 tomcat upgrade to 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
