### PR TITLE
CCD-4210 CVE-2022-45143 - upgrade Tomcat to 9.0.69

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.68',
+  tomcatEmbedded     : '9.0.69',
   serviceAuthVersion : '3.1.4',
 ]
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <suppress>
 <notes>Temporary Suppression
-        CVE-2021-37533 refer [Ticket]
         CVE-2021-4277 refer [Ticket]
         CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2022-45143 refer [Ticket]</notes>
+        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157</notes>
 <cve>CVE-2021-4277</cve>
 <cve>CVE-2022-3064</cve>
 <cve>CVE-2021-4235</cve>
-<cve>CVE-2022-45143</cve>
 </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4210
CVE-2022-45143 - upgrade Tomcat to 9.0.69

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
