### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.69',
+  tomcatEmbedded     : '9.0.73',
   serviceAuthVersion : '3.1.4',
   pact_version       : '4.1.7',
 ]
@@ -253,6 +253,7 @@ repositories {
 
 
 dependencies {
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
@@ -301,7 +302,6 @@ dependencies {
 
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.21'
 
-  // CVE-2022-23181
   implementation "org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"

--- a/charts/ccd-case-document-am-api/Chart.yaml
+++ b/charts/ccd-case-document-am-api/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for CCD Case Document AM API
 name: ccd-case-document-am-api
 home: https://github.com/hmcts/ccd-case-document-am-api
-version: 1.7.8
+version: 1.7.9
 maintainers:
   - name: CCD Team
 dependencies:
   - name: java
-    version: 4.0.12
+    version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <suppress>
 <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]
-        CVE-2023-24998 refer [Ticket]</notes>
+        CVE-2022-45688 refer [Ticket]</notes>
 <cve>CVE-2022-45688</cve>
-<cve>CVE-2023-24998</cve>
 </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
