### PR TITLE
CCD-4739 : Fix-CVE-2023-20863 (bumped versions of springframework and springsecurity)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'info.solidsoft.pitest' version '1.5.0'
-  id 'org.springframework.boot' version '2.6.10'
+  id 'org.springframework.boot' version '2.7.11'
   id 'uk.gov.hmcts.java' version '0.12.40'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
@@ -33,7 +33,7 @@ def versions = [
   lombok             : '1.18.20',
   reformLogging      : '5.1.9',
   serenity           : '2.1.0',
-  springFramework    : '5.3.26',
+  springFramework    : '5.3.27',
   springBoot         : springBoot.class.package.implementationVersion,
   springCloud        : '3.1.3',
   springRetry        : '1.3.4',
@@ -49,8 +49,8 @@ pmd {
   toolVersion = '6.21.0'
   sourceSets = []
 }
-ext['spring-framework.version'] = '5.3.26'
-ext['spring-security.version'] = '5.6.9'
+ext['spring-framework.version'] = '5.3.27'
+ext['spring-security.version'] = '5.7.8'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.32'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,12 +3,11 @@
 <notes>Temporary Suppression
     CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
     CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-    CVE-2023-20863 refer [Ticket]
-        CVE-2023-28709 refer [Ticket]
-        CVE-2023-20883 refer [Ticket]</notes>
+    CVE-2023-28709 refer [Ticket]
+    CVE-2023-20883 refer [Ticket]
+</notes>
 <cve>CVE-2022-45688</cve>
 <cve>CVE-2022-1471</cve>
-<cve>CVE-2023-20863</cve>
 <cve>CVE-2023-28709</cve>
 <cve>CVE-2023-20883</cve>
 </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4739

### Change description ###

CCD-4739 : Fix-CVE-2023-20863 (bumped versions of springframework and springsecurity)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
