### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'io.spring.dependency-management'
 def versions = [
   junit              : '5.6.2',
   lombok             : '1.18.20',
-  reformLogging      : '5.1.9',
+  reformLogging      : '6.0.1',
   serenity           : '2.1.0',
   springFramework    : '5.3.27',
   springBoot         : springBoot.class.package.implementationVersion,


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.