### PR TITLE
CCD-4969 : bumped spring-security.version to v5.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ pmd {
 }
 
 ext['spring-framework.version'] = '5.3.26'
-ext['spring-security.version'] = '5.7.8'
+ext['spring-security.version'] = '5.7.10'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.15.3'
 ext['snakeyaml.version'] = '2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,40 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <suppress>
-<notes>Temporary Suppression
-      CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-      CVE-2023-20883 refer [Ticket]
-      CVE-2023-34036 refer [Ticket]
-      CVE-2023-34034 refer [Ticket]
-      CVE-2023-20873 refer [Ticket]
-      CVE-2023-41080 refer [Ticket]
-      CVE-2023-42794 refer [Ticket]
-      CVE-2023-42795 refer [Ticket]
-      CVE-2023-45648 refer [Ticket]
-      CVE-2023-44487 refer [Ticket]
-      CVE-2023-5072  refer [Ticket]
-      CVE-2023-20863 refer [Ticket]
-  
+  <notes>Temporary Suppression
+        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
+        CVE-2023-20883 refer [Ticket]
+        CVE-2023-34036 refer [Ticket]
+        CVE-2023-20873 refer [Ticket]
+        CVE-2023-41080 refer [Ticket]
+        CVE-2023-42794 refer [Ticket]
+        CVE-2023-42795 refer [Ticket]
+        CVE-2023-45648 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]
+        CVE-2023-5072  refer [Ticket]
+        CVE-2023-20863 refer [Ticket]
         CVE-2023-33202 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2023-6378 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]</notes>
-<cve>CVE-2022-45688</cve>
-<cve>CVE-2023-20883</cve>
-<cve>CVE-2023-34036</cve>
-<cve>CVE-2023-34034</cve>
-<cve>CVE-2023-20873</cve>
-<cve>CVE-2023-41080</cve>
-<cve>CVE-2023-42794</cve>
-<cve>CVE-2023-42795</cve>
-<cve>CVE-2023-45648</cve>
-<cve>CVE-2023-44487</cve>
-<cve>CVE-2023-5072</cve>
-<cve>CVE-2023-20863</cve>
-<cve>CVE-2023-33202</cve>
-<cve>CVE-2023-34055</cve>
-<cve>CVE-2023-46589</cve>
-<cve>CVE-2023-6378</cve>
-<cve>CVE-2023-35116</cve>
+        CVE-2023-35116 refer [Ticket]
+  </notes>
+  <cve>CVE-2022-45688</cve>
+  <cve>CVE-2023-20883</cve>
+  <cve>CVE-2023-34036</cve>
+  <cve>CVE-2023-20873</cve>
+  <cve>CVE-2023-41080</cve>
+  <cve>CVE-2023-42794</cve>
+  <cve>CVE-2023-42795</cve>
+  <cve>CVE-2023-45648</cve>
+  <cve>CVE-2023-44487</cve>
+  <cve>CVE-2023-5072</cve>
+  <cve>CVE-2023-20863</cve>
+  <cve>CVE-2023-33202</cve>
+  <cve>CVE-2023-34055</cve>
+  <cve>CVE-2023-46589</cve>
+  <cve>CVE-2023-6378</cve>
+  <cve>CVE-2023-35116</cve>
 </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

CCD-4969

### Change description ###

bumped spring-security.version to v5.7.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
