### PR TITLE
Fix CVE-2023-42794 : Update org.apache.tomcat.embed to 9.0.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   restAssured        : '4.3.1',
   cucumber           : '5.5.0',
-  tomcatEmbedded     : '9.0.75',
+  tomcatEmbedded     : '9.0.82',
   serviceAuthVersion : '3.1.4',
   pact_version       : '4.1.7',
 ]

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,34 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-<suppress>
-<notes>Temporary Suppression
-      CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-      CVE-2023-34036 refer [Ticket]
-      CVE-2023-20873 refer [Ticket]
-      CVE-2023-41080 refer [Ticket]
-      CVE-2023-42794 refer [Ticket]
-      CVE-2023-42795 refer [Ticket]
-      CVE-2023-45648 refer [Ticket]
-      CVE-2023-44487 refer [Ticket]
-      CVE-2023-5072  refer [Ticket]
-      CVE-2023-33202 refer [Ticket]
-      CVE-2023-34055 refer [Ticket]
-      CVE-2023-46589 refer [Ticket]
-      CVE-2023-6378 refer [Ticket]
-      CVE-2023-35116 refer [Ticket]</notes>
-<cve>CVE-2022-45688</cve>
-<cve>CVE-2023-34036</cve>
-<cve>CVE-2023-20873</cve>
-<cve>CVE-2023-41080</cve>
-<cve>CVE-2023-42794</cve>
-<cve>CVE-2023-42795</cve>
-<cve>CVE-2023-45648</cve>
-<cve>CVE-2023-44487</cve>
-<cve>CVE-2023-5072</cve>
-<cve>CVE-2023-33202</cve>
-<cve>CVE-2023-34055</cve>
-<cve>CVE-2023-46589</cve>
-<cve>CVE-2023-6378</cve>
-<cve>CVE-2023-35116</cve>
-<cve>CVE-2023-34042</cve>
-</suppress>
+  <suppress>
+    <notes>Temporary Suppression
+        CVE-2023-33202 refer [Ticket]
+        CVE-2023-35116 refer [Ticket]
+        CVE-2022-45688 refer [Ticket]
+        CVE-2023-5072 refer [Ticket]
+        CVE-2023-6378 refer [Ticket]
+        CVE-2023-34055 refer [Ticket]
+        CVE-2023-20873 refer [Ticket]
+        CVE-2023-34036 refer [Ticket]
+        CVE-2023-34042 refer [Ticket]
+        CVE-2023-46589 refer [Ticket]</notes>
+    <cve>CVE-2023-33202</cve>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-5072</cve>
+    <cve>CVE-2023-6378</cve>
+    <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-20873</cve>
+    <cve>CVE-2023-34036</cve>
+    <cve>CVE-2023-34042</cve>
+    <cve>CVE-2023-46589</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4973
Fix CVE-2023-42794 : Update org.apache.tomcat.embed to 9.0.82

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
