### PR TITLE
CCD-5159:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,8 +308,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
 
   //CVE-2021-42500
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.13'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.13'
 
   // CVE-2021-28170
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -308,8 +308,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
 
   //CVE-2021-42500
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
 
   // CVE-2021-28170
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,7 +6,6 @@
             CVE-2022-45688 refer [Ticket]
             CVE-2023-5072 refer [Ticket]
             CVE-2023-1370 refer [Ticket]
-            CVE-2023-6378 refer [Ticket]
             CVE-2023-34055 refer [Ticket]
             CVE-2023-20873 refer [Ticket]
             CVE-2023-46589 refer [Ticket]</notes>
@@ -14,7 +13,6 @@
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-1370</cve>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-46589</cve>


### PR DESCRIPTION
Fix CVE-2023-6378, upgrading logback-core and logback-classic from 1.2.10 to 1.5.6.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5159


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
