### PR TITLE
Change jurisdiction and casetypeid for possessions

### DIFF
--- a/src/main/resources/service_config.json
+++ b/src/main/resources/service_config.json
@@ -356,7 +356,7 @@
     },
     {
       "id": "pcs_api",
-      "caseTypeId": ["PCS"],
+      "caseTypeId": ["*"],
       "jurisdictionId": "PCS",
       "permissions": [
         "CREATE",


### PR DESCRIPTION

### JIRA link (if applicable) ###

N/A

### Change description ###

- It was agreed to change the jurisdiction id to PCS, but have description contain civil in the UI.
- Changing casetype id to * as its only pcs now and will help us handle dynamic casetypes in preview (pcs-489)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
