### PR TITLE
CME-820 Reduce logging costs and fix Renovate App Insights tracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
 ARG JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom"
+# renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
 ARG APP_INSIGHTS_AGENT_VERSION=3.7.3
 ARG PLATFORM=""
 

--- a/src/main/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/documentam/service/impl/DocumentManagementServiceImpl.java
@@ -380,7 +380,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
                 || (!StringUtils.isEmpty(caseTypeId)
                     && (caseTypeIds.contains("*") || caseTypeIds.contains(caseTypeId)));
 
-        log.info("Case Type Id is {} and validation result is {}", caseTypeId, result);
+        log.debug("Case Type Id is {} and validation result is {}", caseTypeId, result);
 
         return result;
     }
@@ -392,7 +392,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             || (!StringUtils.isEmpty(jurisdictionId) && (serviceConfig.getJurisdictionId().equals("*")
                 || serviceConfig.getJurisdictionId().equals(jurisdictionId)));
 
-        log.info("JurisdictionI Id is {} and validation result is {}", jurisdictionId, result);
+        log.debug("Jurisdictional Id is {} and validation result is {}", jurisdictionId, result);
 
         return result;
     }
@@ -400,7 +400,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     private boolean validatePermissions(AuthorisedService serviceConfig, Permission permission) {
         List<Permission> servicePermissions = serviceConfig.getPermissions();
         boolean result = !servicePermissions.isEmpty() && (servicePermissions.contains(permission));
-        log.info("Permission is {} and validation result is {}", permission, result);
+        log.debug("Permission is {} and validation result is {}", permission, result);
         return result;
     }
 


### PR DESCRIPTION
### Jira link

See [CME-820](https://tools.hmcts.net/jira/browse/CME-820)

### Change description

Changed validation log statements from INFO to DEBUG level to reduce log volume and costs (~£12/month savings). Fixed Renovate comment position in Dockerfile to enable automatic App Insights agent version updates.

### Testing done

Pipeline testing

### Checklist

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change