### PR TITLE
Onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,5 +1,5 @@
 #!groovy
-@Library("Infrastructure@2.4.0")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 import uk.gov.hmcts.contino.GithubAPI
@@ -86,6 +86,7 @@ env.PACT_BROKER_SCHEME = "https"
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctsprod.azurecr.io/imported/"
 
 withPipeline("java", product, component) {
+  enableCveDashboardIngestion()
   onMaster {
     enablePactAs([
       AppPipelineDsl.PactRoles.PROVIDER


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion for the first time

## Testing
- Jenkinsfile-only configuration change